### PR TITLE
:sparkles: Improve caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,21 @@ const user = client(getCurrentUser());
 
 console.log(user); // should log user
 ```
+
+## Special Utilities
+
+### Cache Busting
+
+As noted, a major benefit of this API wrapper is the intelligent use of caches. However, caches may not always be accurate, or may introduce other issues in certain contexts. As such, there is a special utility for cache busting.
+
+```js
+import { resetCache } from '@ekwoka/spotify-api';
+
+// clears entire cache
+client(resetCache());
+
+// clears specific cached value
+client(resetCache('user')); // should clear user cache only
+```
+
+Where caches are utilized, the documentation for those endpoints will include information about the cache key(s) used.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
+export { resetCache } from './resetCache';
 export { setToken } from './setToken';
 export { spotifyApiClient } from './spotifyApiClient';
 export type {

--- a/src/core/resetCache.test.ts
+++ b/src/core/resetCache.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { PersistentApiProperties, resetCache } from './';
+
+describe('Reset Cache', () => {
+  it('should return a function', () => {
+    expect(typeof resetCache()).toBe('function');
+  });
+  it('should remove the specified piece of the cache', () => {
+    const Client = {
+      cache: { foo: 'bar', fizz: 'buzz' },
+    } as unknown as PersistentApiProperties;
+    resetCache('foo')(Client);
+    expect(Client.cache).toEqual({ fizz: 'buzz' });
+  });
+  it('should remove all cache if no cacheType is provided', () => {
+    const Client = {
+      cache: { foo: 'bar', fizz: 'buzz' },
+    } as unknown as PersistentApiProperties;
+    resetCache()(Client);
+    expect(Client.cache).toEqual({});
+  });
+});

--- a/src/core/resetCache.ts
+++ b/src/core/resetCache.ts
@@ -1,0 +1,14 @@
+import { QueryConstructor } from './types';
+
+/**
+ * The resetCache utility cleans out the cache on the active client, either
+ * entirely emptying the cache, or by selectively invalidating cache via
+ * the passed in property. This is useful for forcing refreshed data.
+ * @param cacheType string
+ * @returns void
+ */
+export const resetCache: QueryConstructor =
+  (cacheType?: string) => (Client) => {
+    if (!cacheType) Client.cache = {};
+    else delete Client.cache[cacheType];
+  };

--- a/src/core/setToken.ts
+++ b/src/core/setToken.ts
@@ -1,5 +1,4 @@
-import { PersistentApiProperties, QueryConstructor } from './';
+import { QueryConstructor } from './';
 
-export const setToken: QueryConstructor =
-  (newToken: string) => (Client: PersistentApiProperties) =>
-    (Client.token = newToken);
+export const setToken: QueryConstructor = (newToken: string) => (Client) =>
+  (Client.token = newToken);

--- a/src/core/spotifyApiClient.ts
+++ b/src/core/spotifyApiClient.ts
@@ -8,11 +8,10 @@ export function spotifyApiClient(token: string): SpotifyApiClient {
   if (!token) throw 'Token is required at Spotify API Initialization';
   const ApiClient: PersistentApiProperties = {
     token,
+    cache: {},
   };
 
   return <T>(fn: QueryFunction<T>): T => {
-    if (!ApiClient.token) throw new Error('Current token is invalid');
-
     return fn(ApiClient);
   };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,6 @@
 export interface PersistentApiProperties {
   token: string;
+  cache: { [key: string]: unknown };
 }
 
 export type SpotifyApiClient = <T>(fn: QueryFunction<T>) => T;

--- a/src/endpoints/users/getCurrentUser.test.ts
+++ b/src/endpoints/users/getCurrentUser.test.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import { beforeAll, describe, expect, it } from 'vitest';
-import { refreshToken } from '../../../auth';
-import { spotifyApiClient } from '../../spotifyApiClient';
+import { refreshToken } from '../../auth';
+import { spotifyApiClient } from '../../core/spotifyApiClient';
 import { getCurrentUser } from './getCurrentUser';
 
 describe('Get Current User', () => {

--- a/src/endpoints/users/getCurrentUser.ts
+++ b/src/endpoints/users/getCurrentUser.ts
@@ -1,5 +1,5 @@
 import { QueryConstructor } from '../..';
-import { deepFreeze, spotifyFetch } from '../../../utils';
+import { deepFreeze, spotifyFetch } from '../../utils';
 
 let cachedUser: User | undefined;
 

--- a/src/endpoints/users/getCurrentUser.ts
+++ b/src/endpoints/users/getCurrentUser.ts
@@ -1,8 +1,6 @@
 import { QueryConstructor } from '../..';
 import { deepFreeze, spotifyFetch } from '../../utils';
 
-let cachedUser: User | undefined;
-
 /**
  * Accesses the Spotify /me endpoint to get information regarding the current
  * user. The User data is cached and put in deep freeze to prevent needing
@@ -11,12 +9,12 @@ let cachedUser: User | undefined;
  */
 export const getCurrentUser: QueryConstructor<Promise<User>> =
   () =>
-  async ({ token }) => {
-    if (cachedUser) return cachedUser;
+  async ({ token, cache }) => {
+    if (cache.user) return cache.user as User;
     const endpoint = `me`;
     const data = await spotifyFetch<User>(endpoint, token);
     deepFreeze(data);
-    cachedUser = data;
+    cache.user = data;
     return data;
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,14 @@
+export { refreshToken } from './auth/refreshToken';
+export { tokensFromCode } from './auth/tokensFromCode';
 export { SPOTIFY_URL } from './constants';
-export { getCurrentUser } from './core/endpoints/users/getCurrentUser';
 export { setToken } from './core/setToken';
 export { spotifyApiClient } from './core/spotifyApiClient';
+export { getCurrentUser } from './endpoints/users/getCurrentUser';
 export { deepFreeze } from './utils/deepFreeze';
+export { isBrowser, isNode } from './utils/isBrowserOrNode';
 export { spotifyFetch } from './utils/spotifyFetch';
+export { toBase64 } from './utils/toBase64';
+export type { SpotifyTokens } from './auth/tokensFromCode';
 export type {
   PersistentApiProperties,
   SpotifyApiClient,


### PR DESCRIPTION
This PR improves the structure of the cache (storing it on the client itself to more easily be utilized in many place) as well as adding a utility for busting the cache when needed.

Storing the cache on the client make cache sharing and cache busting trivial by nature. Having caches stored around the source in different localized areas would be quite a hassle.

The jury is still out on whether more explicit typing of the caches will be necessary.