### PR TITLE
:goal_net: Handles Spotify API Errors explicitely

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { deepFreeze } from './deepFreeze';
 export { isBrowser, isNode } from './isBrowserOrNode';
+export { sleep } from './sleep';
 export { spotifyFetch } from './spotifyFetch';
 export { toBase64 } from './toBase64';

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,1 @@
+export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));

--- a/src/utils/spotifyFetch.test.ts
+++ b/src/utils/spotifyFetch.test.ts
@@ -14,9 +14,13 @@ describe('spotifyFetch', () => {
     expect(user.email).toBeDefined();
   });
   it('should throw on invalid endpoint', async () => {
-    await expect(() => spotifyFetch('invalid', token)).rejects.toThrow();
+    await expect(() => spotifyFetch('invalid', token)).rejects.toThrow(
+      'Not Found'
+    );
   });
   it('should throw on invalid token', async () => {
-    await expect(() => spotifyFetch('me', 'invalid')).rejects.toThrow();
+    await expect(() => spotifyFetch('me', 'invalid')).rejects.toThrow(
+      'Token Expired'
+    );
   });
 });

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { deepFreeze, isBrowser, isNode, toBase64 } from './';
+import { deepFreeze, isBrowser, isNode, toBase64, sleep } from './';
 
 describe('Utils', () => {
   it('should deep freeze', () => {
@@ -22,5 +22,11 @@ describe('Utils', () => {
   });
   it('encodes string to base64', () => {
     expect(toBase64('test')).toBe('dGVzdA==');
+  });
+  it('sleeps', async () => {
+    const start = Date.now();
+    await sleep(100);
+    const end = Date.now();
+    expect(end - start).toBeGreaterThan(98);
   });
 });


### PR DESCRIPTION
This explicitly handles known/expected error codes returned by the Spotify API.

In response to API rate limiting, the fetch delays and then automatically reattempts. Other errors are thrown higher.

It's unknown how one might truly test 403 and 429 errors.

This also adds a sleep utility function and associated test.