### PR TITLE
:sparkles: Adds getUserProfile Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ Options:
 - `offset`: The index of the first item to return. Default: `0`.
 - `time_range`: Over what time frame the data is retrieved. Options: `short_term`, `medium_term`, `long_term`. Default: `medium_term`.
 
+#### getUserProfile
+
+Get's another user's profile by ID
+
+```js
+const thekwoka = await client(getUserProfile('thekwoka'));
+```
+
 ## Special Utilities
 
 ### Cache Busting

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ This document serves the purpose of documenting the progress of the API. This ca
 
 - [x] [GET Current User Profile](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-current-users-profile) - `/me`
 - [x] [GET User's Top Items](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks) - `/me/top/{type}`
-- [ ] [GET User Profile by ID](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-profile) - `/users/{user_id}`
+- [x] [GET User Profile by ID](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-profile) - `/users/{user_id}`
 
 > Note: These next two could be merged to a single wrapper endpoint
 

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "1.92 kB",
-    "raw": 1922
+    "pretty": "2.01 kB",
+    "raw": 2010
   },
   "gzipped": {
-    "pretty": "967 B",
-    "raw": 967
+    "pretty": "998 B",
+    "raw": 998
   }
 }

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,0 +1,5 @@
+export { getCurrentUser } from './users/getCurrentUser';
+export { getTopItems } from './users/getTopItems';
+export { getUserProfile } from './users/getUserProfile';
+export type { Artist, ArtistStub } from './artists/types';
+export type { Track, AlbumStub } from './tracks/types';

--- a/src/endpoints/users/getCurrentUser.test.ts
+++ b/src/endpoints/users/getCurrentUser.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { makeMock } from '../../../testingTools/makeMock';
 import { spotifyApiClient } from '../../core/spotifyApiClient';
-import { getCurrentUser } from './getCurrentUser';
+import { getCurrentUser } from './';
 
 describe('Get Current User', () => {
   beforeAll(() => {

--- a/src/endpoints/users/getTopItems.test.ts
+++ b/src/endpoints/users/getTopItems.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { makeMock } from '../../../testingTools/makeMock';
-import { getTopItems } from './getTopItems';
+import { getTopItems } from './';
 
 describe('getTopItems', () => {
   beforeAll(() => {

--- a/src/endpoints/users/getUserProfile.test.ts
+++ b/src/endpoints/users/getUserProfile.test.ts
@@ -1,0 +1,38 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { makeMock } from '../../../testingTools/makeMock';
+import { getUserProfile } from './';
+
+describe('getUserProfile', () => {
+  beforeAll(() => {
+    makeMock('v1/users/thekwoka', { data: mockedUser }).persist();
+  });
+  it('should return user profile', async () => {
+    const user = await getUserProfile('thekwoka')({
+      token: 'token',
+      cache: {},
+    });
+    expect(user.display_name).toBe('string');
+  });
+});
+
+const mockedUser = {
+  display_name: 'string',
+  external_urls: {
+    spotify: 'string',
+  },
+  followers: {
+    href: 'string',
+    total: 0,
+  },
+  href: 'string',
+  id: 'string',
+  images: [
+    {
+      url: 'https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n',
+      height: 300,
+      width: 300,
+    },
+  ],
+  type: 'user',
+  uri: 'string',
+};

--- a/src/endpoints/users/getUserProfile.ts
+++ b/src/endpoints/users/getUserProfile.ts
@@ -1,0 +1,33 @@
+import { QueryFunction } from '../../core';
+import { Image, spotifyFetch, SpotifyPageURL } from '../../utils';
+
+/**
+ * Consumes the 'user/{user_id}' endpoint to return basic information about
+ * other users, like curators of public playlists or friends of the user.
+ * This returns a limited stub similar to the current user's own data.
+ * @param user_id
+ * @returns OtherUser
+ */
+export const getUserProfile =
+  (user_id: string): QueryFunction<Promise<OtherUser>> =>
+  async ({ token }) => {
+    const endpoint = `users/${user_id}`;
+    const data = await spotifyFetch<OtherUser>(endpoint, token);
+    return data;
+  };
+
+type OtherUser = {
+  display_name: string;
+  external_urls: {
+    spotify: SpotifyPageURL;
+  };
+  followers: {
+    href: null;
+    total: number;
+  };
+  href: string;
+  id: string;
+  images: Image[];
+  type: 'user';
+  uri: string;
+};

--- a/src/endpoints/users/index.ts
+++ b/src/endpoints/users/index.ts
@@ -1,0 +1,3 @@
+export { getCurrentUser } from './getCurrentUser';
+export { getTopItems } from './getTopItems';
+export { getUserProfile } from './getUserProfile';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,18 +4,16 @@ export { tokensFromCode } from './auth/tokensFromCode';
 export { resetCache } from './core/resetCache';
 export { setToken } from './core/setToken';
 export { spotifyApiClient } from './core/spotifyApiClient';
-export { getCurrentUser } from './endpoints/users/getCurrentUser';
-export { getTopItems } from './endpoints/users/getTopItems';
+export { getCurrentUser, getTopItems, getUserProfile } from './endpoints';
 export { spotifyFetch } from './utils/spotifyFetch';
-export type { RefreshedToken } from './auth/refreshToken';
-export type { SpotifyTokens } from './auth/tokensFromCode';
+export type { RefreshedToken } from './auth';
+export type { SpotifyTokens } from './auth';
 export type {
   PersistentApiProperties,
   SpotifyApiClient,
   QueryFunction,
 } from './core/types';
-export type { Artist, ArtistStub } from './endpoints/artists/types';
-export type { Track, AlbumStub } from './endpoints/tracks/types';
+export type { Artist, ArtistStub, Track, AlbumStub } from './endpoints';
 export type {
   Image,
   SpotifyPageURL,


### PR DESCRIPTION
Adds `getUserProfile` endpoints and accompanying tests and documentation