### PR TITLE
:sparkles: Batches and caches Albums

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "vitest.enable": true,
-  "vitest.showFailMessages": true
+  "vitest.showFailMessages": true,
+  "vitest.commandLine": "bun run test:run --"
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@ This document serves the purpose of documenting the progress of the API. This ca
 
 - [x] [GET Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-album) - `/albums/{id}`
 - [x] [GET Several Albums](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-multiple-albums) - `/albums`
-- [ ] [GET Album Tracks](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-albums-tracks) - `/albums/{id}/tracks`
+- [x] [GET Album Tracks](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-albums-tracks) - `/albums/{id}/tracks`
 - [ ] [GET Saved Albums](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-saved-albums) - `/me/albums`
 
 > NOTE: These two can likely be merged

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "size": "node scripts/esbuild.js",
+    "size:test": "NODE_ENV=test node scripts/esbuild.js",
     "build": "tsc",
     "lint": "eslint --fix ./src; prettier --write ./src --loglevel error",
     "lint:check": "eslint --max-warnings 0 ./src && prettier --check ./src",

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -4,11 +4,12 @@ import { join } from 'node:path';
 import { gzipSize } from 'gzip-size';
 import prettyBytes from 'pretty-bytes';
 
+const test = process.env.NODE_ENV === 'test';
 build({
   entryPoints: ['./src/index.ts'],
   inject: [],
   outfile: 'testing/bundle.js',
-  write: false,
+  write: test,
   splitting: false,
   format: 'esm',
   bundle: true,

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "3.13 kB",
-    "raw": 3128
+    "pretty": "3.21 kB",
+    "raw": 3212
   },
   "gzipped": {
-    "pretty": "1.46 kB",
-    "raw": 1457
+    "pretty": "1.5 kB",
+    "raw": 1497
   }
 }

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "2.5 kB",
-    "raw": 2496
+    "pretty": "3.13 kB",
+    "raw": 3128
   },
   "gzipped": {
-    "pretty": "1.15 kB",
-    "raw": 1154
+    "pretty": "1.46 kB",
+    "raw": 1457
   }
 }

--- a/src/endpoints/albums/batchAlbums.ts
+++ b/src/endpoints/albums/batchAlbums.ts
@@ -1,0 +1,20 @@
+import { Albums } from '.';
+import {
+  BatchedFunction,
+  batchWrap,
+  spotifyFetch,
+  toURLString,
+} from '../../utils/';
+import { Album } from './types';
+
+export const batchAlbums: BatchedFunction<Album> = batchWrap(
+  async (token, ids, market: string) => {
+    const endpoint = `albums?${toURLString({
+      ids: ids.join(','),
+      ...(market && { market }),
+    })}`;
+    const data = await spotifyFetch<Albums>(endpoint, token);
+    return data.albums;
+  },
+  20
+);

--- a/src/endpoints/albums/batchAlbums.ts
+++ b/src/endpoints/albums/batchAlbums.ts
@@ -7,6 +7,11 @@ import {
 } from '../../utils/';
 import { Album } from './types';
 
+/**
+ * Wraps up the function for requesting multiple albums from the Spotify API
+ * in a BatchedFunction Wrapper for use in the album endpoints, reducing
+ * the number of calls to Spotify's API. Album IDs in, Album Data Out.
+ */
 export const batchAlbums: BatchedFunction<Album> = batchWrap(
   async (token, ids, market: string) => {
     const endpoint = `albums?${toURLString({

--- a/src/endpoints/albums/getAlbum.test.ts
+++ b/src/endpoints/albums/getAlbum.test.ts
@@ -15,7 +15,7 @@ describe('getAlbum', () => {
           data: mockedAlbums,
         };
       },
-    });
+    }).persist();
     makeMock('v1/albums?ids=GOOD&market=EN', {
       handler: (req) => {
         if (!hasToken(req.headers as unknown as string[]))
@@ -46,6 +46,14 @@ describe('getAlbum', () => {
       'EN'
     )({ token: 'token', cache: {} })) as unknown as { market: string };
     expect(market).toEqual('EN');
+  });
+  it('caches album result', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = {} as Record<string, any>;
+    const album1 = await getAlbum('GOOD')({ token: 'token', cache });
+    expect(cache.albums?.GOOD).toBe(album1);
+    const album2 = await getAlbum('GOOD')({ token: 'token', cache });
+    expect(album1).toBe(album2);
   });
 });
 

--- a/src/endpoints/albums/getAlbum.ts
+++ b/src/endpoints/albums/getAlbum.ts
@@ -4,9 +4,9 @@ import { deepFreeze } from '../../utils';
 import { Album } from './types';
 
 /**
- * Gets single album by ID. This endpoint is implemented through getAlbums to
- * allow for improved performance and a smaller bundle size. In the future
- * this endpoint will batch and cache album data to limit requests.
+ * Gets single album by ID. This endpoint is the center of the main albums
+ * endpoints allowing for improved performance and smaller bundle sizes.
+ * This handles the individual calls to batch the requests together.
  * @param id string
  * @param market string
  * @returns Album

--- a/src/endpoints/albums/getAlbum.ts
+++ b/src/endpoints/albums/getAlbum.ts
@@ -1,5 +1,6 @@
 import { batchAlbums } from '.';
 import { QueryFunction } from '../../core';
+import { deepFreeze } from '../../utils';
 import { Album } from './types';
 
 /**
@@ -12,7 +13,10 @@ import { Album } from './types';
  */
 export const getAlbum =
   (id: string, market?: string): QueryFunction<Promise<Album>> =>
-  async ({ token }) => {
+  async ({ token, cache }) => {
+    if (!cache.albums) cache.albums = {};
+    if (cache.albums[id]) return cache.albums[id];
     const album = await batchAlbums(token, id, market);
+    cache.albums[id] = deepFreeze(album);
     return album;
   };

--- a/src/endpoints/albums/getAlbum.ts
+++ b/src/endpoints/albums/getAlbum.ts
@@ -1,4 +1,4 @@
-import { getAlbums } from '.';
+import { batchAlbums } from '.';
 import { QueryFunction } from '../../core';
 import { Album } from './types';
 
@@ -12,7 +12,7 @@ import { Album } from './types';
  */
 export const getAlbum =
   (id: string, market?: string): QueryFunction<Promise<Album>> =>
-  async (client) => {
-    const { albums } = await getAlbums([id], market)(client);
-    return albums[0];
+  async ({ token }) => {
+    const album = await batchAlbums(token, id, market);
+    return album;
   };

--- a/src/endpoints/albums/getAlbumTracks.ts
+++ b/src/endpoints/albums/getAlbumTracks.ts
@@ -1,5 +1,5 @@
 import { QueryFunction } from '../../core';
-import { getAlbums, TrackList } from './';
+import { batchAlbums, TrackList } from './';
 
 /**
  * Gets single album's TrackList by ID. This endpoint is implemented through
@@ -11,7 +11,7 @@ import { getAlbums, TrackList } from './';
  */
 export const getAlbumTracks =
   (id: string, market?: string): QueryFunction<Promise<TrackList>> =>
-  async (client) => {
-    const { albums } = await getAlbums([id], market)(client);
-    return albums[0].tracks;
+  async ({ token }) => {
+    const album = await batchAlbums(token, id, market);
+    return album.tracks;
   };

--- a/src/endpoints/albums/getAlbumTracks.ts
+++ b/src/endpoints/albums/getAlbumTracks.ts
@@ -3,8 +3,8 @@ import { getAlbum, TrackList } from './';
 
 /**
  * Gets single album's TrackList by ID. This endpoint is implemented through
- * getAlbums to allow for improved performance and a smaller bundle size.
- * In the future, this endpoint will batch and cache Tracklist info.
+ * getAlbum to allow for improved performance and a smaller bundle size.
+ * This batches Tracklist Requests into single calls to the API.
  * @param id string
  * @param market string
  * @returns TrackList

--- a/src/endpoints/albums/getAlbumTracks.ts
+++ b/src/endpoints/albums/getAlbumTracks.ts
@@ -1,5 +1,5 @@
 import { QueryFunction } from '../../core';
-import { batchAlbums, TrackList } from './';
+import { getAlbum, TrackList } from './';
 
 /**
  * Gets single album's TrackList by ID. This endpoint is implemented through
@@ -11,7 +11,7 @@ import { batchAlbums, TrackList } from './';
  */
 export const getAlbumTracks =
   (id: string, market?: string): QueryFunction<Promise<TrackList>> =>
-  async ({ token }) => {
-    const album = await batchAlbums(token, id, market);
+  async (client) => {
+    const album = await getAlbum(id, market)(client);
     return album.tracks;
   };

--- a/src/endpoints/albums/getAlbums.test.ts
+++ b/src/endpoints/albums/getAlbums.test.ts
@@ -23,7 +23,13 @@ describe('getAlbums', () => {
         return {
           statusCode: 200,
           data: {
-            market: new URLSearchParams(req.path.split('?')[1]).get('market'),
+            albums: [
+              {
+                market: new URLSearchParams(req.path.split('?')[1]).get(
+                  'market'
+                ),
+              },
+            ],
           },
         };
       },
@@ -39,16 +45,74 @@ describe('getAlbums', () => {
   });
 
   it('should pass market as query param', async () => {
-    const { market } = (await getAlbums(
-      ['testid'],
-      'EN'
-    )({ token: 'token', cache: {} })) as unknown as { market: string };
+    const {
+      albums: [{ market }],
+    } = await getAlbums(['testid'], 'EN')({ token: 'token', cache: {} });
     expect(market).toEqual('EN');
   });
 });
 
 const mockedAlbums = {
   albums: [
+    {
+      album_type: 'compilation',
+      total_tracks: 9,
+      available_markets: ['CA', 'BR', 'IT'],
+      external_urls: {
+        spotify: 'string',
+      },
+      href: 'string',
+      id: '2up3OPMp9Tb4dAKM2erWXQ',
+      images: [
+        {
+          url: 'https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n',
+          height: 300,
+          width: 300,
+        },
+      ],
+      name: 'string',
+      release_date: '1981-12',
+      release_date_precision: 'year',
+      restrictions: {
+        reason: 'market',
+      },
+      type: 'album',
+      uri: 'spotify:album:2up3OPMp9Tb4dAKM2erWXQ',
+      artists: [
+        {
+          external_urls: {
+            spotify: 'string',
+          },
+          followers: {
+            href: 'string',
+            total: 0,
+          },
+          genres: ['Prog rock', 'Grunge'],
+          href: 'string',
+          id: 'string',
+          images: [
+            {
+              url: 'https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n',
+              height: 300,
+              width: 300,
+            },
+          ],
+          name: 'string',
+          popularity: 0,
+          type: 'artist',
+          uri: 'string',
+        },
+      ],
+      tracks: {
+        href: 'https://api.spotify.com/v1/me/shows?offset=0&limit=20\n',
+        items: [{}],
+        limit: 20,
+        next: 'https://api.spotify.com/v1/me/shows?offset=1&limit=1',
+        offset: 0,
+        previous: 'https://api.spotify.com/v1/me/shows?offset=1&limit=1',
+        total: 4,
+      },
+    },
     {
       album_type: 'compilation',
       total_tracks: 9,

--- a/src/endpoints/albums/getAlbums.test.ts
+++ b/src/endpoints/albums/getAlbums.test.ts
@@ -47,7 +47,7 @@ describe('getAlbums', () => {
   });
 });
 
-export const mockedAlbums = {
+const mockedAlbums = {
   albums: [
     {
       album_type: 'compilation',

--- a/src/endpoints/albums/getAlbums.ts
+++ b/src/endpoints/albums/getAlbums.ts
@@ -2,8 +2,8 @@ import { Album, getAlbum } from '.';
 import { QueryFunction } from '../../core';
 /**
  * Gets multiple albums with one request to Spotify. Market limits the search
- * to a specific market. In the future, this endpoint will intelligently
- * batch and cache requests to improve performance and limit requests.
+ * to a specific market. This endpoint is passes the album IDs to getAlbum
+ * to allow for intelligent batching with a reduced bundle size.
  * @param ids string[]
  * @param market string
  * @returns Albums

--- a/src/endpoints/albums/getAlbums.ts
+++ b/src/endpoints/albums/getAlbums.ts
@@ -1,6 +1,5 @@
-import { Album } from '.';
+import { Album, batchAlbums } from '.';
 import { QueryFunction } from '../../core';
-import { spotifyFetch, toURLString } from '../../utils';
 /**
  * Gets multiple albums with one request to Spotify. Market limits the search
  * to a specific market. In the future, this endpoint will intelligently
@@ -12,12 +11,10 @@ import { spotifyFetch, toURLString } from '../../utils';
 export const getAlbums =
   (ids: string[], market?: string): QueryFunction<Promise<Albums>> =>
   async ({ token }) => {
-    const endpoint = `albums?${toURLString({
-      ids: ids.join(','),
-      ...(market && { market }),
-    })}`;
-    const data = await spotifyFetch<Albums>(endpoint, token);
-    return data;
+    const albums = await Promise.all(
+      ids.map((id) => batchAlbums(token, id, market))
+    );
+    return { albums };
   };
 
 export type Albums = {

--- a/src/endpoints/albums/getAlbums.ts
+++ b/src/endpoints/albums/getAlbums.ts
@@ -1,4 +1,4 @@
-import { Album, batchAlbums } from '.';
+import { Album, getAlbum } from '.';
 import { QueryFunction } from '../../core';
 /**
  * Gets multiple albums with one request to Spotify. Market limits the search
@@ -10,9 +10,9 @@ import { QueryFunction } from '../../core';
  */
 export const getAlbums =
   (ids: string[], market?: string): QueryFunction<Promise<Albums>> =>
-  async ({ token }) => {
+  async (client) => {
     const albums = await Promise.all(
-      ids.map((id) => batchAlbums(token, id, market))
+      ids.map((id) => getAlbum(id, market)(client))
     );
     return { albums };
   };

--- a/src/endpoints/albums/index.ts
+++ b/src/endpoints/albums/index.ts
@@ -1,3 +1,4 @@
+export { batchAlbums } from './batchAlbums';
 export { getAlbum } from './getAlbum';
 export { getAlbums } from './getAlbums';
 export { getAlbumTracks } from './getAlbumTracks';

--- a/src/utils/arrayWrap.ts
+++ b/src/utils/arrayWrap.ts
@@ -1,0 +1,4 @@
+export const arrayWrap = <T>(maybe: T | T[]): T[] => {
+  if (Array.isArray(maybe)) return maybe;
+  return [maybe];
+};

--- a/src/utils/batchRequests.test.ts
+++ b/src/utils/batchRequests.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { batchWrap } from './';
+
+describe('batchRequests', () => {
+  const testCallback = (token: string, input: string[]): Promise<string[]> =>
+    Promise.all(input.map((x) => x + token));
+  it('returns a function', () => {
+    expect(batchWrap(testCallback));
+  });
+  it('passes data through', async () => {
+    const batch = batchWrap(testCallback);
+    const result = await batch('token', 'a');
+    expect(result).toEqual('atoken');
+  });
+  it('handles multiple calls', async () => {
+    const batch = batchWrap(testCallback);
+    const results = await Promise.all(['a', 'b'].map((x) => batch('token', x)));
+    expect(results).toEqual(['atoken', 'btoken']);
+  });
+  it('batches requests', async () => {
+    const spy = vi.fn(testCallback);
+    const batch = batchWrap(spy);
+    const results = await Promise.all(['a', 'b'].map((x) => batch('token', x)));
+    expect(results).toEqual(['atoken', 'btoken']);
+    expect(spy).toHaveBeenCalledOnce();
+  });
+  it('rejects if the callback throws', async () => {
+    const batch = batchWrap(() => {
+      throw new Error('test');
+    });
+    await expect(batch('token', 'a')).rejects.toThrow('test');
+  });
+});

--- a/src/utils/batchRequests.ts
+++ b/src/utils/batchRequests.ts
@@ -1,5 +1,13 @@
 import { chunkArray, debounce } from './';
 
+/**
+ * This is the core system for batching requests to Spotify's API. This piece
+ * is used in the creation of batched endpoints and returns a function to
+ * be called when wanting to add a new request to the batched queue.
+ * @param cb string[] => any[]
+ * @param max number
+ * @returns BatchedFunction
+ */
 export const batchWrap = <T extends string, S>(
   cb: BatchCallback<T, S>,
   max = 20

--- a/src/utils/batchRequests.ts
+++ b/src/utils/batchRequests.ts
@@ -1,0 +1,65 @@
+import { chunkArray, debounce } from './';
+
+export const batchWrap = <T extends string, S>(
+  cb: BatchCallback<T, S>,
+  max = 20
+): ((tkn: string, id: string) => Promise<S>) => {
+  let batch: BatchQueue<S> = {};
+  const addToBatch = (item: T, res: ResolveBatch<S>) => {
+    if (!batch[item]) batch[item] = [];
+    batch[item].push(res);
+  };
+  const performRequests = debounce((token: string) => {
+    performBatchedRequest(token, batch, cb, max);
+    batch = {};
+  }, 50);
+
+  return (token: string, id: T): Promise<S> => {
+    return new Promise((res, rej) => {
+      addToBatch(id, resOrRej(res, rej));
+      performRequests(token);
+    });
+  };
+};
+
+const resOrRej = <T>(res: (val: T) => void, rej: (err: Error) => void) => {
+  return (val: T | Error) => {
+    if (val instanceof Error) rej(val);
+    else res(val);
+  };
+};
+
+const performBatchedRequest = <T extends string, S>(
+  token: string,
+  batchQueue: BatchQueue<S>,
+  cb: BatchCallback<T, S>,
+  max: number
+) => {
+  const batches = chunkArray(Object.keys(batchQueue), max) as T[][];
+  batches.forEach(async (batch) => {
+    try {
+      const dataToReturn = await cb(token, batch);
+      while (batch.length) {
+        const resolves = batchQueue[batch.pop()];
+        const nextData = dataToReturn.pop();
+        resolves.forEach((res) => res(nextData));
+      }
+    } catch (e) {
+      while (batch.length) {
+        const resolves = batchQueue[batch.pop()];
+        resolves.forEach((res) => res(e));
+      }
+    }
+  });
+};
+
+type BatchCallback<T extends string, S> = (
+  token: string,
+  data: T[]
+) => Promise<S[]>;
+
+type BatchQueue<S> = {
+  [key: string]: ResolveBatch<S>[];
+};
+
+type ResolveBatch<S> = (res: S) => void;

--- a/src/utils/chunkArray.ts
+++ b/src/utils/chunkArray.ts
@@ -1,0 +1,10 @@
+export const chunkArray = <T>(
+  arr: T[],
+  maxSize: number,
+  mutate = false
+): T[][] => {
+  if (!mutate) arr = [...arr];
+  const output: T[][] = [];
+  while (arr.length) output.push(arr.splice(0, maxSize));
+  return output;
+};

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,10 @@
+export const debounce = <F extends (...args: unknown[]) => void>(
+  func: F,
+  wait = 400
+): F => {
+  let timeout: string | number | NodeJS.Timeout;
+  return ((...args: Parameters<F>) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  }) as F;
+};

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   deepFreeze,
@@ -7,7 +7,10 @@ import {
   toBase64,
   sleep,
   toURLString,
-} from './';
+  debounce,
+  chunkArray,
+  arrayWrap,
+} from '.';
 
 describe('Utils', () => {
   it('should deep freeze', () => {
@@ -43,5 +46,27 @@ describe('Utils', () => {
         baz: 'qux',
       })
     ).toBe('foo=1&baz=qux');
+  });
+  it('debounces', async () => {
+    const spy = vi.fn().mockImplementation(() => null);
+    const debounced = debounce(spy, 10);
+    expect(debounced).toBeInstanceOf(Function);
+    debounced();
+    debounced();
+    debounced();
+    await sleep(20);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+  it('chunks an array into designated size', () => {
+    expect(chunkArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3)).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+      [10],
+    ]);
+  });
+  it('wraps non-array in an array', () => {
+    expect(arrayWrap(1)).toEqual([1]);
+    expect(arrayWrap([1, 2, 3])).toEqual([1, 2, 3]);
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,7 @@
+export { arrayWrap } from './arrayWrap';
+export { batchWrap } from './batchRequests';
+export { chunkArray } from './chunkArray';
+export { debounce } from './debounce';
 export { deepFreeze } from './deepFreeze';
 export { isBrowser, isNode } from './isBrowserOrNode';
 export { sleep } from './sleep';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@ export { sleep } from './sleep';
 export { spotifyFetch } from './spotifyFetch';
 export { toBase64 } from './toBase64';
 export { toURLString } from './toURLString';
+export type { BatchedFunction } from './batchRequests';
 export type {
   Image,
   SpotifyPageURL,


### PR DESCRIPTION
Solves the problem of limiting API requests by batching multiple calls to the different albums endpoints into the minimum number of requests to the API.

- Docs Updates
- Comments Includes
- Test Coverage 100% on relevant code

Size Increase: 1154B => 1497B