### PR TITLE
:sparkles: Saved albums endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,24 @@ Currently Available methods in the Albums category include:
 - `getAlbum` - Retrieves info about an album by ID
 - `getAlbums` - Retrieves info about multiple albums by ID
 - `getAlbumTracks` - Retrieves info about an albums tracks
+- `getSavedAlbums` - Retrieves a paginated list of albums in the user's library
 
 > While these correspond to 3 different endpoints to Spotify's API, internally these 3 use only the `getAlbums` endpoints for improved code-reuse.
 
-Cachekey: 'albums.[id]'
+Cachekey: `albums.[id]`
 Batching Limit: 20
 
-### getAlbum
+
+- `albumIsSaved` - Retrieves whether a provided album id is in the user's library
+- `saveAlbums` - Adds albums to the user's library
+- `removeAlbums` - Removes albums from the user's library
+
+> These last 3 all use batching to improve performance, and these 3 all also use a shared cache of in-Library states.
+
+Cachekey: `saved.albums[id]`
+Batching Limit: 20
+
+#### getAlbum
 
 Gets details of an Album by ID.
 
@@ -157,6 +168,47 @@ const album = client(getAlbumTracks('6tLZvqqoWszgPagzzNNQQF'));
 const albumInMarket = client(getAlbumTracks('6tLZvqqoWszgPagzzNNQQF', 'KR'));
 ```
 
+#### getSavedAlbums
+
+Gets a list of the users saved albums (those in the users library)
+
+```js
+const savedAlbums = client(getSavedAlbums())
+const savedAlbumsLong = client(getSavedAlbums({ limit: 50 }))
+```
+
+Options:
+
+- `limit`: The number of items to return. Default: `20`. Maximum: `50`.
+- `offset`: The index of the first item to return. Default: `0`.
+- `time_range`: Over what time frame the data is retrieved. Options: `short_term`, `medium_term`, `long_term`. Default: `medium_term`.
+
+#### albumIsSaved
+
+Gets whether the provided album IDs are present in the user's library. Works with single IDs or arrays of IDs.
+
+```js
+const isSaved = client(albumIsSaved('6tLZvqqoWszgPagzzNNQQF')) // true | false
+const areSaved = client(albumIsSaved(['6tLZvqqoWszgPagzzNNQQF', '6XBIkDFhDgc3PQOUEcO2fd'])) // [true, false]
+```
+
+#### saveAlbums
+
+Puts album ID into the user's library. Returns `true` if successful. Works with single IDs or arrays of IDs.
+```js
+const isSaved = client(saveAlbums('6tLZvqqoWszgPagzzNNQQF')) // true
+const wasSaved = client(saveAlbums(['6tLZvqqoWszgPagzzNNQQF', '6XBIkDFhDgc3PQOUEcO2fd'])) // [true, true]
+```
+
+#### removeAlbums
+
+Deletes album ID from the user's library. Returns `true` if successful. Works with single IDs or arrays of IDs.
+```js
+const isRemoved = client(removeAlbums('6tLZvqqoWszgPagzzNNQQF')) // true
+const wasRemoved = client(removeAlbums(['6tLZvqqoWszgPagzzNNQQF', '6XBIkDFhDgc3PQOUEcO2fd'])) // [true, true]
+```
+
+
 ### Users
 
 Currently Available methods in the Users category include:
@@ -175,7 +227,7 @@ const user = client(getCurrentUser());
 console.log(user); // should log user
 ```
 
-cache key: 'user'
+CacheKey: `user`
 
 #### getTopItems
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,8 @@ This document serves the purpose of documenting the progress of the API. This ca
 
 > NOTE: These two can likely be merged
 
-- [ ] [PUT Save Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/save-albums-user) - `/me/albums`
-- [ ] [DELETE Remove Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/remove-albums-user) - `/me/albums`
+- [x] [PUT Save Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/save-albums-user) - `/me/albums`
+- [x] [DELETE Remove Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/remove-albums-user) - `/me/albums`
 - [x] [GET If User Saved Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/check-users-saved-albums) - `/me/albums/contains`
 - [ ] [GET New Releases](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-new-releases) - `/browser/new-releases`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,13 +19,13 @@ This document serves the purpose of documenting the progress of the API. This ca
 - [x] [GET Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-album) - `/albums/{id}`
 - [x] [GET Several Albums](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-multiple-albums) - `/albums`
 - [x] [GET Album Tracks](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-albums-tracks) - `/albums/{id}/tracks`
-- [ ] [GET Saved Albums](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-saved-albums) - `/me/albums`
+- [x] [GET Saved Albums](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-saved-albums) - `/me/albums`
 
 > NOTE: These two can likely be merged
 
 - [ ] [PUT Save Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/save-albums-user) - `/me/albums`
 - [ ] [DELETE Remove Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/remove-albums-user) - `/me/albums`
-- [ ] [GET If User Saved Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/check-users-saved-albums) - `/me/albums/contains`
+- [x] [GET If User Saved Album](https://developer.spotify.com/documentation/web-api/reference/#/operations/check-users-saved-albums) - `/me/albums/contains`
 - [ ] [GET New Releases](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-new-releases) - `/browser/new-releases`
 
 ### Search

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "3.73 kB",
-    "raw": 3734
+    "pretty": "3.74 kB",
+    "raw": 3737
   },
   "gzipped": {
     "pretty": "1.66 kB",
-    "raw": 1660
+    "raw": 1663
   }
 }

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "3.74 kB",
-    "raw": 3737
+    "pretty": "4.24 kB",
+    "raw": 4242
   },
   "gzipped": {
-    "pretty": "1.66 kB",
-    "raw": 1663
+    "pretty": "1.79 kB",
+    "raw": 1787
   }
 }

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "3.21 kB",
-    "raw": 3212
+    "pretty": "3.73 kB",
+    "raw": 3734
   },
   "gzipped": {
-    "pretty": "1.5 kB",
-    "raw": 1497
+    "pretty": "1.66 kB",
+    "raw": 1660
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,4 +5,5 @@ export type {
   PersistentApiProperties,
   SpotifyApiClient,
   QueryFunction,
+  PaginatedList,
 } from './types';

--- a/src/core/resetCache.test.ts
+++ b/src/core/resetCache.test.ts
@@ -17,6 +17,11 @@ describe('Reset Cache', () => {
       cache: { foo: 'bar', fizz: 'buzz' },
     } as unknown as PersistentApiProperties;
     resetCache()(Client);
-    expect(Client.cache).toEqual({});
+    expect(Client.cache).toEqual({
+      albums: {},
+      saved: {
+        albums: {},
+      },
+    });
   });
 });

--- a/src/core/resetCache.ts
+++ b/src/core/resetCache.ts
@@ -10,6 +10,12 @@ import { QueryFunction } from './types';
 export const resetCache =
   (cacheType?: string): QueryFunction =>
   (Client) => {
-    if (!cacheType) Client.cache = {};
+    if (!cacheType)
+      Client.cache = {
+        albums: {},
+        saved: {
+          albums: {},
+        },
+      };
     else delete Client.cache[cacheType];
   };

--- a/src/core/spotifyApiClient.ts
+++ b/src/core/spotifyApiClient.ts
@@ -9,7 +9,12 @@ export function spotifyApiClient(token: string): SpotifyApiClient {
     throw new TypeError('Token is required at Spotify API Initialization');
   const ApiClient: PersistentApiProperties = {
     token,
-    cache: {},
+    cache: {
+      albums: {},
+      saved: {
+        albums: {},
+      },
+    },
   };
 
   return <T>(fn: QueryFunction<T>): T => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,7 +1,27 @@
+import { Album } from '../endpoints/albums';
+
 export type PersistentApiProperties = {
   token: string;
-  cache: { [key: string]: unknown };
+  cache: {
+    albums?: Record<string, Album>;
+    [key: string]: unknown;
+  };
 };
 
 export type SpotifyApiClient = <T>(fn: QueryFunction<T>) => T;
 export type QueryFunction<T = void> = (props: PersistentApiProperties) => T;
+
+export type PaginatedList<T> = {
+  href: string;
+  items: T[];
+  limit: number;
+  next: string | null;
+  offset: number;
+  previous: string | null;
+  total: number;
+};
+
+export type Copyrights = {
+  text: string;
+  type: string;
+}[];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,7 +3,10 @@ import { Album } from '../endpoints/albums';
 export type PersistentApiProperties = {
   token: string;
   cache: {
-    albums?: Record<string, Album>;
+    albums: Record<string, Album>;
+    saved: {
+      albums: Record<string, boolean>;
+    };
     [key: string]: unknown;
   };
 };

--- a/src/endpoints/albums/albumIsSaved.test.ts
+++ b/src/endpoints/albums/albumIsSaved.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { hasToken, makeMock } from '../../../testingTools';
+import { PersistentApiProperties } from '../../core';
+import { albumIsSaved } from './';
+
+describe('albumIsSaved', () => {
+  beforeAll(() => {
+    makeMock('v1/albums/contains?ids=seoul%2Cdrip', {
+      handler: (req) => {
+        if (!hasToken(req.headers as unknown as string[]))
+          return { statusCode: 401 };
+        return {
+          statusCode: 200,
+          data: [true, false],
+        };
+      },
+    }).persist();
+    makeMock('v1/albums/contains?ids=seoul', {
+      handler: (req) => {
+        if (!hasToken(req.headers as unknown as string[]))
+          return { statusCode: 401 };
+        return {
+          statusCode: 200,
+          data: [true],
+        };
+      },
+    }).persist();
+  });
+  it('should return a function', () => {
+    expect(typeof albumIsSaved('seoul')).toBe('function');
+  });
+  it('should return true is album is saved (string)', async () => {
+    const isSaved = await albumIsSaved('seoul')({
+      token: 'token',
+      cache: { saved: { albums: {} } } as PersistentApiProperties['cache'],
+    });
+    expect(isSaved).toEqual(true);
+  });
+  it('should return true is album is saved (array)', async () => {
+    const isSaved = await albumIsSaved(['seoul'])({
+      token: 'token',
+      cache: { saved: { albums: {} } } as PersistentApiProperties['cache'],
+    });
+    expect(isSaved).toEqual([true]);
+  });
+  it('should work with multiple albums', async () => {
+    const isSaved = await albumIsSaved(['seoul', 'drip'])({
+      token: 'token',
+      cache: { saved: { albums: {} } } as PersistentApiProperties['cache'],
+    });
+    expect(isSaved).toEqual([true, false]);
+  });
+  it('should batch requests', async () => {
+    const isSaved = await Promise.all(
+      ['seoul', 'drip'].map((item) =>
+        albumIsSaved(item)({
+          token: 'token',
+          cache: { saved: { albums: {} } } as PersistentApiProperties['cache'],
+        })
+      )
+    );
+    expect(isSaved).toEqual([true, false]);
+  });
+  it('should cache requests', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = { saved: { albums: {} } } as PersistentApiProperties['cache'];
+    const isSaved = await albumIsSaved('seoul')({
+      token: 'token',
+      cache,
+    });
+    const isSaved2 = await albumIsSaved('seoul')({
+      token: 'token',
+      cache,
+    });
+    expect(isSaved).toEqual(true);
+    expect(isSaved2).toEqual(true);
+    expect(cache.saved.albums).toEqual({ seoul: true });
+  });
+});

--- a/src/endpoints/albums/albumIsSaved.test.ts
+++ b/src/endpoints/albums/albumIsSaved.test.ts
@@ -5,7 +5,7 @@ import { albumIsSaved } from './';
 
 describe('albumIsSaved', () => {
   beforeAll(() => {
-    makeMock('v1/albums/contains?ids=seoul%2Cdrip', {
+    makeMock('v1/me/albums/contains?ids=seoul%2Cdrip', {
       handler: (req) => {
         if (!hasToken(req.headers as unknown as string[]))
           return { statusCode: 401 };
@@ -15,7 +15,7 @@ describe('albumIsSaved', () => {
         };
       },
     }).persist();
-    makeMock('v1/albums/contains?ids=seoul', {
+    makeMock('v1/me/albums/contains?ids=seoul', {
       handler: (req) => {
         if (!hasToken(req.headers as unknown as string[]))
           return { statusCode: 401 };

--- a/src/endpoints/albums/albumIsSaved.ts
+++ b/src/endpoints/albums/albumIsSaved.ts
@@ -33,7 +33,9 @@ type AlbumIsSaved = {
 
 const batchAlbumIsSaved: BatchedFunction<boolean> = batchWrap(
   async (token, ids) => {
-    const endpoint = `albums/contains?${toURLString({ ids: ids.join(',') })}`;
+    const endpoint = `me/albums/contains?${toURLString({
+      ids: ids.join(','),
+    })}`;
     const data = await spotifyFetch<boolean[]>(endpoint, token);
     return data;
   }

--- a/src/endpoints/albums/albumIsSaved.ts
+++ b/src/endpoints/albums/albumIsSaved.ts
@@ -1,0 +1,40 @@
+import { PersistentApiProperties, QueryFunction } from '../../core';
+import {
+  BatchedFunction,
+  batchWrap,
+  spotifyFetch,
+  toURLString,
+} from '../../utils';
+
+export const albumIsSaved: AlbumIsSaved = ((
+  album: string | string[]
+): QueryFunction<Promise<boolean>> | QueryFunction<Promise<boolean[]>> => {
+  if (Array.isArray(album))
+    return (client) =>
+      Promise.all(album.map((id) => cacheAlbumIsSaved(client, id)));
+  return (client) => cacheAlbumIsSaved(client, album);
+}) as AlbumIsSaved;
+
+const cacheAlbumIsSaved = async (
+  { token, cache }: PersistentApiProperties,
+  album: string
+): Promise<boolean> => {
+  const subCache = cache.saved.albums;
+  if (subCache[album]) return subCache[album];
+  const data = await batchAlbumIsSaved(token, album);
+  subCache[album] = data;
+  return data;
+};
+
+type AlbumIsSaved = {
+  (albumId: string): QueryFunction<Promise<boolean>>;
+  (albumIds: string[]): QueryFunction<Promise<boolean[]>>;
+};
+
+const batchAlbumIsSaved: BatchedFunction<boolean> = batchWrap(
+  async (token, ids) => {
+    const endpoint = `albums/contains?${toURLString({ ids: ids.join(',') })}`;
+    const data = await spotifyFetch<boolean[]>(endpoint, token);
+    return data;
+  }
+);

--- a/src/endpoints/albums/albumIsSaved.ts
+++ b/src/endpoints/albums/albumIsSaved.ts
@@ -6,6 +6,13 @@ import {
   toURLString,
 } from '../../utils';
 
+/**
+ * Checks whether a provided album ID (or IDs in array) exist in the current
+ * user's library. Returns a boolean of the status. Batches requests and
+ * Caches the result in the saved albums cache for easier retrieval.
+ * @param album: string | string[]
+ * @returns boolean | boolean[]
+ */
 export const albumIsSaved: AlbumIsSaved = ((
   album: string | string[]
 ): QueryFunction<Promise<boolean>> | QueryFunction<Promise<boolean[]>> => {

--- a/src/endpoints/albums/getSavedAlbums.test.ts
+++ b/src/endpoints/albums/getSavedAlbums.test.ts
@@ -1,0 +1,310 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getSavedAlbums, SavedAlbum } from '.';
+import { hasToken, makeMock } from '../../../testingTools';
+import { PaginatedList, PersistentApiProperties } from '../../core';
+
+describe('getAlbumTracks', () => {
+  beforeAll(() => {
+    makeMock('v1/me/albums?', {
+      handler: (req) => {
+        if (!hasToken(req.headers as unknown as string[]))
+          return { statusCode: 401 };
+        return {
+          statusCode: 200,
+          data: mockedAlbums,
+        };
+      },
+    }).persist();
+    makeMock('v1/me/albums?limit=1&market=EN&offset=5', {
+      handler: (req) => {
+        if (!hasToken(req.headers as unknown as string[]))
+          return { statusCode: 401 };
+        const params = new URLSearchParams(req.path.split('?')[1]);
+        return {
+          statusCode: 200,
+          data: {
+            ...mockedAlbums,
+            market: params.get('market'),
+            limit: params.get('limit'),
+            offset: params.get('offset'),
+          },
+        };
+      },
+    });
+  });
+  it('should return a function', () => {
+    const fn = getSavedAlbums();
+    expect(typeof fn).toBe('function');
+  });
+  it('should return an Album List', async () => {
+    const savedAlbumsPage = await getSavedAlbums()({
+      token: 'token',
+      cache: {},
+    });
+    expect(savedAlbumsPage).toEqual(mockedAlbums);
+  });
+  it('should pass options as query params', async () => {
+    const { limit, offset, market } = (await getSavedAlbums({
+      limit: 1,
+      market: 'EN',
+      offset: 5,
+    })({
+      token: 'token',
+      cache: {},
+    })) as unknown as PaginatedList<SavedAlbum> & { market: string };
+    expect(limit).toBe('1');
+    expect(offset).toBe('5');
+    expect(market).toBe('EN');
+  });
+  it('should cache the albums returned', async () => {
+    const Client = { token: 'token', cache: {} } as PersistentApiProperties;
+    const savedAlbumsPage = await getSavedAlbums()(Client);
+    expect(
+      Client.cache.albums[savedAlbumsPage.items[0].album.id]
+    ).toBeDefined();
+  });
+});
+
+const mockedAlbums: PaginatedList<SavedAlbum> = {
+  href: 'https://api.spotify.com/v1/me/albums?offset=0&limit=1&locale=en-US,en;q=0.9,ko-KR;q=0.8,ko;q=0.7',
+  items: [
+    {
+      added_at: '2022-04-24T08:55:15Z',
+      album: {
+        album_type: 'single',
+        artists: [
+          {
+            external_urls: {
+              spotify: 'https://open.spotify.com/artist/4k5fFEYgkWYrYvtOK3zVBl',
+            },
+            href: 'https://api.spotify.com/v1/artists/4k5fFEYgkWYrYvtOK3zVBl',
+            id: '4k5fFEYgkWYrYvtOK3zVBl',
+            name: 'BOL4',
+            type: 'artist',
+            uri: 'spotify:artist:4k5fFEYgkWYrYvtOK3zVBl',
+          },
+        ],
+        available_markets: ['AD'],
+        copyrights: [
+          {
+            text: '2022 쇼파르엔터테인먼트, under license to NHN Bugs Corp',
+            type: 'C',
+          },
+          {
+            text: '2022 쇼파르엔터테인먼트, under license to NHN Bugs Corp',
+            type: 'P',
+          },
+        ],
+        external_ids: {
+          upc: '191953169354',
+        },
+        external_urls: {
+          spotify: 'https://open.spotify.com/album/6tLZvqqoWszgPagzzNNQQF',
+        },
+        genres: [],
+        href: 'https://api.spotify.com/v1/albums/6tLZvqqoWszgPagzzNNQQF',
+        id: '6tLZvqqoWszgPagzzNNQQF',
+        images: [
+          {
+            height: 640,
+            url: 'https://i.scdn.co/image/ab67616d0000b27378b1c1b27cdfcd891f3a9047',
+            width: 640,
+          },
+          {
+            height: 300,
+            url: 'https://i.scdn.co/image/ab67616d00001e0278b1c1b27cdfcd891f3a9047',
+            width: 300,
+          },
+          {
+            height: 64,
+            url: 'https://i.scdn.co/image/ab67616d0000485178b1c1b27cdfcd891f3a9047',
+            width: 64,
+          },
+        ],
+        label: '쇼파르엔터테인먼트',
+        name: 'Seoul',
+        popularity: 47,
+        release_date: '2022-04-20',
+        release_date_precision: 'day',
+        total_tracks: 5,
+        tracks: {
+          href: 'https://api.spotify.com/v1/albums/6tLZvqqoWszgPagzzNNQQF/tracks?offset=0&limit=50&locale=en-US,en;q=0.9,ko-KR;q=0.8,ko;q=0.7',
+          items: [
+            {
+              artists: [
+                {
+                  external_urls: {
+                    spotify:
+                      'https://open.spotify.com/artist/4k5fFEYgkWYrYvtOK3zVBl',
+                  },
+                  href: 'https://api.spotify.com/v1/artists/4k5fFEYgkWYrYvtOK3zVBl',
+                  id: '4k5fFEYgkWYrYvtOK3zVBl',
+                  name: 'BOL4',
+                  type: 'artist',
+                  uri: 'spotify:artist:4k5fFEYgkWYrYvtOK3zVBl',
+                },
+              ],
+              available_markets: ['AD'],
+              disc_number: 1,
+              duration_ms: 197333,
+              explicit: false,
+              external_urls: {
+                spotify:
+                  'https://open.spotify.com/track/6uEWYpv8HNAdbwHlqemG1F',
+              },
+              href: 'https://api.spotify.com/v1/tracks/6uEWYpv8HNAdbwHlqemG1F',
+              id: '6uEWYpv8HNAdbwHlqemG1F',
+              is_local: false,
+              name: 'Love story',
+              preview_url:
+                'https://p.scdn.co/mp3-preview/eeea43c89b3ab7ed3eb60eecfb6a49844003c3e6?cid=774b29d4f13844c495f206cafdad9c86',
+              track_number: 1,
+              type: 'track',
+              uri: 'spotify:track:6uEWYpv8HNAdbwHlqemG1F',
+            },
+            {
+              artists: [
+                {
+                  external_urls: {
+                    spotify:
+                      'https://open.spotify.com/artist/4k5fFEYgkWYrYvtOK3zVBl',
+                  },
+                  href: 'https://api.spotify.com/v1/artists/4k5fFEYgkWYrYvtOK3zVBl',
+                  id: '4k5fFEYgkWYrYvtOK3zVBl',
+                  name: 'BOL4',
+                  type: 'artist',
+                  uri: 'spotify:artist:4k5fFEYgkWYrYvtOK3zVBl',
+                },
+              ],
+              available_markets: ['AD'],
+              disc_number: 1,
+              duration_ms: 204760,
+              explicit: false,
+              external_urls: {
+                spotify:
+                  'https://open.spotify.com/track/4b9LMCUaw55QajVRfrfPyS',
+              },
+              href: 'https://api.spotify.com/v1/tracks/4b9LMCUaw55QajVRfrfPyS',
+              id: '4b9LMCUaw55QajVRfrfPyS',
+              is_local: false,
+              name: 'Seoul',
+              preview_url:
+                'https://p.scdn.co/mp3-preview/2a59b2615f90941494d5dac5d553e681a4eb1a50?cid=774b29d4f13844c495f206cafdad9c86',
+              track_number: 2,
+              type: 'track',
+              uri: 'spotify:track:4b9LMCUaw55QajVRfrfPyS',
+            },
+            {
+              artists: [
+                {
+                  external_urls: {
+                    spotify:
+                      'https://open.spotify.com/artist/4k5fFEYgkWYrYvtOK3zVBl',
+                  },
+                  href: 'https://api.spotify.com/v1/artists/4k5fFEYgkWYrYvtOK3zVBl',
+                  id: '4k5fFEYgkWYrYvtOK3zVBl',
+                  name: 'BOL4',
+                  type: 'artist',
+                  uri: 'spotify:artist:4k5fFEYgkWYrYvtOK3zVBl',
+                },
+              ],
+              available_markets: ['AD'],
+              disc_number: 1,
+              duration_ms: 155200,
+              explicit: false,
+              external_urls: {
+                spotify:
+                  'https://open.spotify.com/track/0FuDAmNLFEEO3eev0SBFTV',
+              },
+              href: 'https://api.spotify.com/v1/tracks/0FuDAmNLFEEO3eev0SBFTV',
+              id: '0FuDAmNLFEEO3eev0SBFTV',
+              is_local: false,
+              name: 'What make us beautiful',
+              preview_url:
+                'https://p.scdn.co/mp3-preview/4f6822500f1c518ba5c696495c970b1faed4a2a0?cid=774b29d4f13844c495f206cafdad9c86',
+              track_number: 3,
+              type: 'track',
+              uri: 'spotify:track:0FuDAmNLFEEO3eev0SBFTV',
+            },
+            {
+              artists: [
+                {
+                  external_urls: {
+                    spotify:
+                      'https://open.spotify.com/artist/4k5fFEYgkWYrYvtOK3zVBl',
+                  },
+                  href: 'https://api.spotify.com/v1/artists/4k5fFEYgkWYrYvtOK3zVBl',
+                  id: '4k5fFEYgkWYrYvtOK3zVBl',
+                  name: 'BOL4',
+                  type: 'artist',
+                  uri: 'spotify:artist:4k5fFEYgkWYrYvtOK3zVBl',
+                },
+              ],
+              available_markets: ['AD'],
+              disc_number: 1,
+              duration_ms: 183720,
+              explicit: false,
+              external_urls: {
+                spotify:
+                  'https://open.spotify.com/track/7n5jmLC8G2Lt2wOb0PST8x',
+              },
+              href: 'https://api.spotify.com/v1/tracks/7n5jmLC8G2Lt2wOb0PST8x',
+              id: '7n5jmLC8G2Lt2wOb0PST8x',
+              is_local: false,
+              name: 'In the mirror',
+              preview_url:
+                'https://p.scdn.co/mp3-preview/59a9468550c32a579ee6cc67b3b3e8ae3085aeae?cid=774b29d4f13844c495f206cafdad9c86',
+              track_number: 4,
+              type: 'track',
+              uri: 'spotify:track:7n5jmLC8G2Lt2wOb0PST8x',
+            },
+            {
+              artists: [
+                {
+                  external_urls: {
+                    spotify:
+                      'https://open.spotify.com/artist/4k5fFEYgkWYrYvtOK3zVBl',
+                  },
+                  href: 'https://api.spotify.com/v1/artists/4k5fFEYgkWYrYvtOK3zVBl',
+                  id: '4k5fFEYgkWYrYvtOK3zVBl',
+                  name: 'BOL4',
+                  type: 'artist',
+                  uri: 'spotify:artist:4k5fFEYgkWYrYvtOK3zVBl',
+                },
+              ],
+              available_markets: ['AD'],
+              disc_number: 1,
+              duration_ms: 207986,
+              explicit: false,
+              external_urls: {
+                spotify:
+                  'https://open.spotify.com/track/5apKI7Cwh4wJhefjCnf7rt',
+              },
+              href: 'https://api.spotify.com/v1/tracks/5apKI7Cwh4wJhefjCnf7rt',
+              id: '5apKI7Cwh4wJhefjCnf7rt',
+              is_local: false,
+              name: 'Star',
+              preview_url:
+                'https://p.scdn.co/mp3-preview/738df04d6c0706cab173eb235e8dca03e26922b2?cid=774b29d4f13844c495f206cafdad9c86',
+              track_number: 5,
+              type: 'track',
+              uri: 'spotify:track:5apKI7Cwh4wJhefjCnf7rt',
+            },
+          ],
+          limit: 50,
+          next: null,
+          offset: 0,
+          previous: null,
+          total: 5,
+        },
+        type: 'album',
+        uri: 'spotify:album:6tLZvqqoWszgPagzzNNQQF',
+      },
+    },
+  ],
+  limit: 1,
+  next: 'https://api.spotify.com/v1/me/albums?offset=1&limit=1&locale=en-US,en;q=0.9,ko-KR;q=0.8,ko;q=0.7',
+  offset: 0,
+  previous: null,
+  total: 5,
+};

--- a/src/endpoints/albums/getSavedAlbums.ts
+++ b/src/endpoints/albums/getSavedAlbums.ts
@@ -2,6 +2,16 @@ import { Album } from './';
 import { PaginatedList, QueryFunction } from '../../core';
 import { deepFreeze, spotifyFetch, toURLString } from '../../utils';
 
+/**
+ * Retrieves a paginated list of Albums currently saved in the User's Library.
+ * Accepts options to change the per page limit, as well as the initial
+ * item offset. These can used combined to change the returned page.
+ * @param {Object} options
+ *  {number} options.limit
+ *  {number} options.offset
+ *  {string} options.market
+ * @returns PaginatedList<Albums>
+ */
 export const getSavedAlbums =
   (
     options: SavedAlbumOptions = {}

--- a/src/endpoints/albums/getSavedAlbums.ts
+++ b/src/endpoints/albums/getSavedAlbums.ts
@@ -1,0 +1,28 @@
+import { Album } from './';
+import { PaginatedList, QueryFunction } from '../../core';
+import { deepFreeze, spotifyFetch, toURLString } from '../../utils';
+
+export const getSavedAlbums =
+  (
+    options: SavedAlbumOptions = {}
+  ): QueryFunction<Promise<PaginatedList<SavedAlbum>>> =>
+  async ({ token, cache }) => {
+    const endpoint = `me/albums?${toURLString(options)}`;
+    const data = await spotifyFetch<PaginatedList<SavedAlbum>>(endpoint, token);
+    if (!cache.albums) cache.albums = {};
+    data.items.forEach(
+      ({ album }) => (cache.albums[album.id] = deepFreeze(album))
+    );
+    return data;
+  };
+
+type SavedAlbumOptions = {
+  limit?: number;
+  offset?: number;
+  market?: string;
+};
+
+export type SavedAlbum = {
+  added_at: string;
+  album: Album;
+};

--- a/src/endpoints/albums/index.ts
+++ b/src/endpoints/albums/index.ts
@@ -2,5 +2,7 @@ export { batchAlbums } from './batchAlbums';
 export { getAlbum } from './getAlbum';
 export { getAlbums } from './getAlbums';
 export { getAlbumTracks } from './getAlbumTracks';
+export { getSavedAlbums } from './getSavedAlbums';
 export type { Albums } from './getAlbums';
+export type { SavedAlbum } from './getSavedAlbums';
 export type { AlbumStub, Album, TrackList } from './types';

--- a/src/endpoints/albums/index.ts
+++ b/src/endpoints/albums/index.ts
@@ -1,3 +1,4 @@
+export { albumIsSaved } from './albumIsSaved';
 export { batchAlbums } from './batchAlbums';
 export { getAlbum } from './getAlbum';
 export { getAlbums } from './getAlbums';

--- a/src/endpoints/albums/index.ts
+++ b/src/endpoints/albums/index.ts
@@ -4,6 +4,8 @@ export { getAlbum } from './getAlbum';
 export { getAlbums } from './getAlbums';
 export { getAlbumTracks } from './getAlbumTracks';
 export { getSavedAlbums } from './getSavedAlbums';
+export { removeAlbums } from './removeAlbums';
+export { saveAlbums } from './saveAlbums';
 export type { Albums } from './getAlbums';
 export type { SavedAlbum } from './getSavedAlbums';
 export type { AlbumStub, Album, TrackList } from './types';

--- a/src/endpoints/albums/removeAlbums.ts
+++ b/src/endpoints/albums/removeAlbums.ts
@@ -1,6 +1,13 @@
 import { PersistentApiProperties, QueryFunction } from '../../core';
 import { BatchedFunction, batchWrap, spotifyFetch } from '../../utils';
 
+/**
+ * Removes albums from the current user's library. Accepts both a single ID
+ * as well as an array of album IDs. Will return true if successful and
+ * throw if unsuccessful. Caches new status in the Saved Albums cache.
+ * @param ids: string | string[]
+ * @returns true | true[]
+ */
 export const removeAlbums: RemoveAlbums = ((
   ids: string | string[]
 ): QueryFunction<Promise<boolean>> | QueryFunction<Promise<boolean[]>> => {

--- a/src/endpoints/albums/removeAlbums.ts
+++ b/src/endpoints/albums/removeAlbums.ts
@@ -1,0 +1,36 @@
+import { PersistentApiProperties, QueryFunction } from '../../core';
+import { BatchedFunction, batchWrap, spotifyFetch } from '../../utils';
+
+export const removeAlbums: RemoveAlbums = ((
+  ids: string | string[]
+): QueryFunction<Promise<boolean>> | QueryFunction<Promise<boolean[]>> => {
+  if (Array.isArray(ids))
+    return (client) =>
+      Promise.all(ids.map((id) => cacheSavedAlbums(client, id)));
+  return (client) => cacheSavedAlbums(client, ids);
+}) as RemoveAlbums;
+
+const cacheSavedAlbums = async (
+  { token, cache }: PersistentApiProperties,
+  album: string
+): Promise<boolean> => {
+  const data = await batchRemoveAlbums(token, album);
+  cache.saved.albums[album] = false;
+  return data;
+};
+
+const batchRemoveAlbums: BatchedFunction<boolean> = batchWrap(
+  async (token, ids) => {
+    const endpoint = `me/albums`;
+    const data = await spotifyFetch<boolean[]>(endpoint, token, {
+      method: 'DELETE',
+      body: JSON.stringify({ ids }),
+    });
+    return data;
+  }
+);
+
+type RemoveAlbums = {
+  (albumId: string): QueryFunction<Promise<boolean>>;
+  (albumIds: string[]): QueryFunction<Promise<boolean[]>>;
+};

--- a/src/endpoints/albums/saveAlbums.ts
+++ b/src/endpoints/albums/saveAlbums.ts
@@ -1,0 +1,36 @@
+import { PersistentApiProperties, QueryFunction } from '../../core';
+import { BatchedFunction, batchWrap, spotifyFetch } from '../../utils';
+
+export const saveAlbums: SaveAlbums = ((
+  ids: string | string[]
+): QueryFunction<Promise<boolean>> | QueryFunction<Promise<boolean[]>> => {
+  if (Array.isArray(ids))
+    return (client) =>
+      Promise.all(ids.map((id) => cacheSavedAlbums(client, id)));
+  return (client) => cacheSavedAlbums(client, ids);
+}) as SaveAlbums;
+
+const cacheSavedAlbums = async (
+  { token, cache }: PersistentApiProperties,
+  album: string
+): Promise<boolean> => {
+  const data = await batchSaveAlbums(token, album);
+  cache.saved.albums[album] = true;
+  return data;
+};
+
+const batchSaveAlbums: BatchedFunction<boolean> = batchWrap(
+  async (token, ids) => {
+    const endpoint = `me/albums`;
+    const data = await spotifyFetch<boolean[]>(endpoint, token, {
+      method: 'PUT',
+      body: JSON.stringify({ ids }),
+    });
+    return data;
+  }
+);
+
+type SaveAlbums = {
+  (albumId: string): QueryFunction<Promise<boolean>>;
+  (albumIds: string[]): QueryFunction<Promise<boolean[]>>;
+};

--- a/src/endpoints/albums/saveAlbums.ts
+++ b/src/endpoints/albums/saveAlbums.ts
@@ -1,6 +1,13 @@
 import { PersistentApiProperties, QueryFunction } from '../../core';
 import { BatchedFunction, batchWrap, spotifyFetch } from '../../utils';
 
+/**
+ * Adds an album or albums to the current user's library. Accepts both single
+ * album IDs or an array of album IDs. Will return true if successful and
+ * throw if unsuccessful. Caches new status in the Saved Albums cache.
+ * @param ids: string | string[]
+ * @returns true | true[]
+ */
 export const saveAlbums: SaveAlbums = ((
   ids: string | string[]
 ): QueryFunction<Promise<boolean>> | QueryFunction<Promise<boolean[]>> => {

--- a/src/endpoints/albums/saveOrRemoveAlbums.test.ts
+++ b/src/endpoints/albums/saveOrRemoveAlbums.test.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { hasToken, makeMock } from '../../../testingTools';
+import { saveAlbums, removeAlbums } from './';
+import { PersistentApiProperties } from '../../core';
+
+describe('saveAlbums', () => {
+  beforeAll(() => {
+    makeMock('v1/me/albums', {
+      method: 'PUT',
+      handler: (req) => {
+        if (!hasToken(req.headers as unknown as string[]))
+          return { statusCode: 401 };
+        if (!req.body) return { statusCode: 403 };
+        return {
+          statusCode: 200,
+          data: (JSON.parse(req.body as string) as { ids: string[] }).ids.map(
+            () => true
+          ),
+        };
+      },
+    }).persist();
+  });
+  it('should return a function', () => {
+    expect(typeof saveAlbums('seoul')).toBe('function');
+  });
+  it('should save albums', async () => {
+    const wasSaved = await saveAlbums('seoul')({
+      token: 'token',
+      cache: { saved: { albums: {} } } as PersistentApiProperties['cache'],
+    });
+    expect(wasSaved).toEqual(true);
+  });
+  it('should accept an array of albums', async () => {
+    const wasSaved = await saveAlbums(['seoul', 'drip'])({
+      token: 'token',
+      cache: { saved: { albums: {} } } as PersistentApiProperties['cache'],
+    });
+    expect(wasSaved).toEqual([true, true]);
+  });
+  it('should cache result', async () => {
+    const cache = { saved: { albums: {} } } as PersistentApiProperties['cache'];
+    await saveAlbums('seoul')({ token: 'token', cache });
+    expect(cache.saved.albums).toEqual({ seoul: true });
+  });
+});
+
+describe('removeAlbums', () => {
+  beforeAll(() => {
+    makeMock('v1/me/albums', {
+      method: 'DELETE',
+      handler: (req) => {
+        if (!hasToken(req.headers as unknown as string[]))
+          return { statusCode: 401 };
+        if (!req.body) return { statusCode: 403 };
+        return {
+          statusCode: 200,
+          data: (JSON.parse(req.body as string) as { ids: string[] }).ids.map(
+            () => true
+          ),
+        };
+      },
+    }).persist();
+  });
+  it('should return a function', () => {
+    expect(typeof removeAlbums('seoul')).toBe('function');
+  });
+  it('should save albums', async () => {
+    const wasRemoved = await removeAlbums('seoul')({
+      token: 'token',
+      cache: { saved: { albums: {} } } as PersistentApiProperties['cache'],
+    });
+    expect(wasRemoved).toEqual(true);
+  });
+  it('should accept an array of albums', async () => {
+    const wasRemoved = await removeAlbums(['seoul', 'drip'])({
+      token: 'token',
+      cache: { saved: { albums: {} } } as PersistentApiProperties['cache'],
+    });
+    expect(wasRemoved).toEqual([true, true]);
+  });
+  it('should cache result', async () => {
+    const cache = {
+      saved: { albums: {} },
+    } as PersistentApiProperties['cache'];
+    await removeAlbums('seoul')({ token: 'token', cache });
+    expect(cache.saved.albums).toEqual({ seoul: false });
+  });
+});

--- a/src/endpoints/albums/types.ts
+++ b/src/endpoints/albums/types.ts
@@ -1,6 +1,7 @@
+import { Copyrights } from '../../core/types';
 import { SpotifyAPIURL, SpotifyPageURL, Image } from '../../utils';
 import { ArtistStub } from '../artists/';
-import { Track } from '../tracks/';
+import { TrackStub } from '../tracks/types';
 
 export type AlbumStub = {
   album_type: 'single' | 'album' | 'compilation';
@@ -25,10 +26,15 @@ export type Album = AlbumStub & {
     reason: 'market' | 'product' | 'explicit';
   };
   tracks: TrackList;
+  copyrights?: Copyrights;
+  external_ids: Record<string, string>;
+  genres: string[];
+  label: string;
+  popularity: number;
 };
 export type TrackList = {
   href: SpotifyAPIURL;
-  items: Track[];
+  items: TrackStub[];
   limit: number;
   next: SpotifyAPIURL | null;
   offset: number;

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,10 +1,14 @@
+export { albumIsSaved } from './albums/albumIsSaved';
+export { batchAlbums } from './albums/batchAlbums';
 export { getAlbum } from './albums/getAlbum';
 export { getAlbums } from './albums/getAlbums';
 export { getAlbumTracks } from './albums/getAlbumTracks';
+export { getSavedAlbums } from './albums/getSavedAlbums';
 export { getCurrentUser } from './users/getCurrentUser';
 export { getTopItems } from './users/getTopItems';
 export { getUserProfile } from './users/getUserProfile';
 export type { Albums } from './albums/getAlbums';
+export type { SavedAlbum } from './albums/getSavedAlbums';
 export type { AlbumStub, Album, TrackList } from './albums/types';
 export type { Artist, ArtistStub } from './artists/types';
-export type { Track } from './tracks/types';
+export type { Track, TrackStub } from './tracks/types';

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -4,6 +4,8 @@ export { getAlbum } from './albums/getAlbum';
 export { getAlbums } from './albums/getAlbums';
 export { getAlbumTracks } from './albums/getAlbumTracks';
 export { getSavedAlbums } from './albums/getSavedAlbums';
+export { removeAlbums } from './albums/removeAlbums';
+export { saveAlbums } from './albums/saveAlbums';
 export { getCurrentUser } from './users/getCurrentUser';
 export { getTopItems } from './users/getTopItems';
 export { getUserProfile } from './users/getUserProfile';

--- a/src/endpoints/tracks/types.ts
+++ b/src/endpoints/tracks/types.ts
@@ -2,18 +2,22 @@ import { SpotifyAPIURL, SpotifyPageURL } from '../../utils/SpotifyUtilityTypes';
 import { AlbumStub } from '../albums';
 import { ArtistStub } from '../artists/types';
 
-export type Track = {
+export type Track = TrackStub & {
   album: AlbumStub;
-  artists: ArtistStub[];
-  available_markets: string[];
-  disc_number: number;
-  duration_ms: number;
-  explicit: boolean;
   external_ids: {
     isrc?: string;
     ean?: string;
     upc?: string;
   };
+  popularity: number;
+};
+
+export type TrackStub = {
+  artists: ArtistStub[];
+  available_markets: string[];
+  disc_number: number;
+  duration_ms: number;
+  explicit: boolean;
   external_urls: {
     spotify: SpotifyPageURL;
   };
@@ -21,7 +25,6 @@ export type Track = {
   id: string;
   is_local: boolean;
   name: string;
-  popularity: number;
   preview_url: string;
   track_number: number;
   type: 'track';

--- a/src/endpoints/users/getTopItems.ts
+++ b/src/endpoints/users/getTopItems.ts
@@ -1,4 +1,4 @@
-import { QueryFunction } from '../../core';
+import { QueryFunction, PaginatedList } from '../../core';
 import { spotifyFetch, toURLString } from '../../utils';
 import { Artist } from '../artists/types';
 import { Track } from '../tracks/types';
@@ -7,7 +7,7 @@ export const getTopItems: GetTopItems =
   (type, options = {}) =>
   async ({ token }) => {
     const endpoint = `me/top/${type}?${toURLString(options)}`;
-    const data = await spotifyFetch<TopItems<TopItem[typeof type]>>(
+    const data = await spotifyFetch<PaginatedList<TopItem[typeof type]>>(
       endpoint,
       token
     );
@@ -17,17 +17,7 @@ export const getTopItems: GetTopItems =
 type GetTopItems = <T extends keyof TopItem>(
   type: T,
   options?: TopItemOptions
-) => QueryFunction<Promise<TopItems<TopItem[T]>>>;
-
-type TopItems<T> = {
-  href: 'string';
-  items: T[];
-  limit: number;
-  next: string;
-  offset: number;
-  previous: string;
-  total: number;
-};
+) => QueryFunction<Promise<PaginatedList<TopItem[T]>>>;
 
 type TopItem = {
   tracks: Track;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export {
   getAlbumTracks,
   getSavedAlbums,
   albumIsSaved,
+  saveAlbums,
+  removeAlbums,
 } from './endpoints';
 export { spotifyFetch } from './utils/spotifyFetch';
 export type { RefreshedToken } from './auth';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export {
   getAlbum,
   getAlbums,
   getAlbumTracks,
+  getSavedAlbums,
+  albumIsSaved,
 } from './endpoints';
 export { spotifyFetch } from './utils/spotifyFetch';
 export type { RefreshedToken } from './auth';

--- a/src/utils/deepFreeze.ts
+++ b/src/utils/deepFreeze.ts
@@ -1,4 +1,4 @@
-export const deepFreeze = (obj: unknown) => {
+export const deepFreeze = <T>(obj: T): Readonly<T> => {
   Object.keys(obj).forEach((key) => {
     if (typeof obj[key] === 'object' && !Object.isFrozen(obj[key])) {
       deepFreeze(obj[key]);

--- a/src/utils/spotifyFetch.ts
+++ b/src/utils/spotifyFetch.ts
@@ -27,7 +27,7 @@ export const spotifyFetch = async <T>(
   } catch (e) {
     /**
      * Spotify API Error Handling
-     * 401: Bad of Expired Token. Should reauthenticate.
+     * 401: Bad or Expired Token. Should reauthenticate.
      * 403: Forbidden. Fatal Error.
      * 404: Not Found. Internal Error.
      * 429: Too Many Requests. Should wait and reattempt.

--- a/testingTools/index.ts
+++ b/testingTools/index.ts
@@ -1,0 +1,3 @@
+export { hasToken } from "./hasToken";
+export { makeMock } from "./makeMock";
+export { mockAgent, mockPool } from "./mockAgent";


### PR DESCRIPTION
Adds endpoints for:
- saved albums
- checking if album is saved
- saving album
- removing album

Includes:
- documentation
- tests

Concerns:
- `saveAlbums` and `removeAlbums` have quite a lot of shared code, probably around 90% even, and this could likely be combined.