### PR TITLE
:sparkles: Implements addToQueue endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,16 +268,26 @@ const albumsInMarket = client(
 
 Endpoints included in the Player category include:
 
+- `addToQueue` - Posts new item to the current playback queue
 - `recentlyPlayedTracks` - Gets user's recently played tracks
 
+#### addToQueue
+
+Posts the provided item URI (track or episode) to the active playback queue.
+
+```js
+client(addToQueue('spotify:track:5expoVGQPvXuwBBFuNGqBd'))
+```
+
+If there is any error, this function will throw (as with all endpoints) but will return `null` when successful.
 
 #### recentlyPlayedTracks
 
 Get the user's recently played tracks and their playing context (like in a playlist or artist). Results can be filtered by play date
 
 ```js
-const recentlyPlayed = client(recentlyPlayed())
-const recentlypPlayedFiltered = client(recentlyPlayed({ 
+const recentlyPlayed = await client(recentlyPlayed())
+const recentlypPlayedFiltered = await client(recentlyPlayed({ 
 	after: 1145736000000, 
 	before: 1653508800000, 
 	limit: 10

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,6 +36,7 @@ This document serves the purpose of documenting the progress of the API. This ca
 ### Player
 
 - [x] [GET Recently Played Tracks](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recently-played) - `me/player/recently-played`
+- [x] [POST Item to current playback queue](https://developer.spotify.com/documentation/web-api/reference/#/operations/add-to-queue) - `me/player/queue`
 
 ### Playlists
 

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "6.26 kB",
-    "raw": 6260
+    "pretty": "6.38 kB",
+    "raw": 6385
   },
   "gzipped": {
-    "pretty": "2.26 kB",
-    "raw": 2264
+    "pretty": "2.32 kB",
+    "raw": 2316
   }
 }

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -10,6 +10,7 @@ export { saveAlbums } from './albums/saveAlbums';
 export { batchArtists } from './artists/batchArtists';
 export { getArtist } from './artists/getArtist';
 export { getArtists } from './artists/getArtists';
+export { addToQueue } from './player/addToQueue';
 export { recentlyPlayedTracks } from './player/recentlyPlayedTracks';
 export { getPlaylist } from './playlists/getPlaylist';
 export { getUsersPlaylists } from './playlists/getUsersPlaylists';

--- a/src/endpoints/player/addToQueue.test.ts
+++ b/src/endpoints/player/addToQueue.test.ts
@@ -1,0 +1,24 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { hasToken, makeMock } from '../../../testingTools';
+import { addToQueue } from './';
+
+describe('addToQueue', () => {
+  beforeAll(() => {
+    makeMock('v1/me/player/queue?uri=uri', {
+      method: 'POST',
+      handler: (req) => {
+        if (!hasToken(req.headers as any)) return { statusCode: 401 };
+        return { statusCode: 204 };
+      },
+    });
+  });
+  it('should return a function', () => {
+    expect(typeof addToQueue('uri')).toBe('function');
+  });
+  it('should add a track to the queue', async () => {
+    const results = await addToQueue('uri')({
+      token: 'token',
+    } as any);
+    expect(results).toBeNull();
+  });
+});

--- a/src/endpoints/player/addToQueue.ts
+++ b/src/endpoints/player/addToQueue.ts
@@ -1,0 +1,16 @@
+import { QueryFunction } from '../../core';
+import { spotifyFetch, toURLString } from '../../utils';
+
+export const addToQueue =
+  (uri: string): QueryFunction<Promise<void>> =>
+  ({ token }) => {
+    const endpoint = `me/player/queue?${toURLString({ uri })}`;
+    return spotifyFetch<void>(
+      endpoint,
+      token,
+      {
+        method: 'POST',
+      },
+      false
+    );
+  };

--- a/src/endpoints/player/index.ts
+++ b/src/endpoints/player/index.ts
@@ -1,3 +1,4 @@
+export { addToQueue } from './addToQueue';
 export { recentlyPlayedTracks } from './recentlyPlayedTracks';
 export type { RecentlyPlayedTrackList } from './recentlyPlayedTracks';
 export type { Context } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
 export { resetCache, setToken, spotifyApiClient } from './core';
 export {
   albumIsSaved,
+  addToQueue,
   getAlbum,
   getAlbums,
   getAlbumTracks,

--- a/src/utils/spotifyFetch.ts
+++ b/src/utils/spotifyFetch.ts
@@ -12,7 +12,8 @@ import { SPOTIFY_URL } from '../constants';
 export const spotifyFetch = async <T>(
   endpoint: string,
   token: string,
-  data: Record<string, unknown> = {}
+  data: Record<string, unknown> = {},
+  hasReturn = true
 ): Promise<T> => {
   try {
     const headers = {
@@ -23,6 +24,7 @@ export const spotifyFetch = async <T>(
       ...data,
     });
     if (!response.ok) throw new Error(response.status.toString());
+    if (!hasReturn) return null;
     return await response.json();
   } catch (e) {
     /**


### PR DESCRIPTION
This implements the `addToQueue` endpoint

includes:
- endpoint
- tests
- documentations
- adjusts `spotifyFetch` to return null on endpoints that don't return things

This does not allow defining a specific device to add the item to.