### PR TITLE
:recycle: Refactor auth helpers for passed in variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ These helpers are:
 - `getTokenFromCode`: Accepts a code from the Spotify authentication flow and returns a suite of tokens (access and refresh).
 - `refreshToken`: Accepts a refresh token and returns a new access token.
 
-These currently depend on you setting up and exposing certain environment variables for the functions to access on the `process.env` object:
+While these functions do allow passing in the valid parameters, you can also depend on evironment variables by setting up and exposing the following on the `process.env` object:
 
 - `SPOTIFY_CLIENT`: Client id from Spotify Developer Dashboard.
 - `SPOTIFY_SECRET`: Client secret.
@@ -82,14 +82,18 @@ import {
 } from '@ekwoka/spotify-api';
 
 const loginHandler = async (req, res) => {
-  const url = makeAuthURL(['user-read-email']);
+  const url = makeAuthURL(['user-read-email'], CLIENT, REDIRECT);
   res.redirect(302, url);
 };
 
 const codeHandler = async (req, res) => {
   try {
     const { code } = JSON.parse(req.body);
-    const { access_token, refresh_token } = await getTokenFromCode(code);
+    const { access_token, refresh_token } = await getTokenFromCode(
+      code,
+      CLIENT,
+      SECRET
+    );
     res.cookie('refresh_token', refresh_token);
     res.status(200).json({ access_token });
   } catch (err) {
@@ -100,7 +104,7 @@ const codeHandler = async (req, res) => {
 const refreshHandler = async (req, res) => {
   try {
     const { refresh_token } = req.cookies;
-    const { access_token } = await refreshToken(refresh_token);
+    const { access_token } = await refreshToken(refresh_token, CLIENT, SECRET);
     res.status(200).json({ access_token });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "6.57 kB",
-    "raw": 6572
+    "pretty": "6.67 kB",
+    "raw": 6666
   },
   "gzipped": {
-    "pretty": "2.38 kB",
-    "raw": 2383
+    "pretty": "2.4 kB",
+    "raw": 2402
   }
 }

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -8,8 +8,6 @@ describe('AUTH Helpers', () => {
       method: 'POST',
       handler: ({ body, headers }) => {
         const params = new URLSearchParams(body as string);
-
-        console.log(headers[1]);
         if (headers[1] !== 'Basic dmFsaWQtY2xpZW50OnN1cGVyc2VjcmV0')
           return { statusCode: 401 };
         if (params.get('grant_type') === 'authorization_code') {

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { makeMock } from '../../testingTools/makeMock';
 import { refreshToken, tokensFromCode, makeAuthURL } from './';
 
@@ -6,8 +6,12 @@ describe('AUTH Helpers', () => {
   beforeAll(() => {
     makeMock('api/token', {
       method: 'POST',
-      handler: ({ body }) => {
+      handler: ({ body, headers }) => {
         const params = new URLSearchParams(body as string);
+
+        console.log(headers[1]);
+        if (headers[1] !== 'Basic dmFsaWQtY2xpZW50OnN1cGVyc2VjcmV0')
+          return { statusCode: 401 };
         if (params.get('grant_type') === 'authorization_code') {
           return params.get('code') === 'valid'
             ? { statusCode: 200, data: mockedTokens }
@@ -22,8 +26,13 @@ describe('AUTH Helpers', () => {
       },
     }).persist();
   });
+  beforeEach(() => {
+    process.env.REDIRECT = undefined;
+    process.env.SPOTIFY_CLIENT = undefined;
+    process.env.SPOTIFY_SECRET = undefined;
+  });
   describe('makeAuthURL', () => {
-    it('should create auth url', () => {
+    it('should create auth url from env variables', () => {
       process.env.REDIRECT = 'http://localhost:3000/';
       process.env.SPOTIFY_CLIENT = 'valid-client';
       process.env.SPOTIFY_SECRET = 'supersecret';
@@ -36,26 +45,62 @@ describe('AUTH Helpers', () => {
         'https://accounts.spotify.com/authorize?response_type=code&client_id=valid-client&scope=streaming+user-read-email+user-read-private&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F'
       );
     });
+    it('should create auth url from passed in variables', () => {
+      const authURL = makeAuthURL(
+        ['streaming', 'user-read-email', 'user-read-private'],
+        'valid-client',
+        'http://localhost:3000/'
+      );
+      expect(authURL).toBe(
+        'https://accounts.spotify.com/authorize?response_type=code&client_id=valid-client&scope=streaming+user-read-email+user-read-private&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F'
+      );
+    });
   });
   describe('refreshToken', () => {
-    it('should refresh access token', async () => {
+    it('should refresh access token from env variables', async () => {
+      process.env.REDIRECT = 'http://localhost:3000/';
+      process.env.SPOTIFY_CLIENT = 'valid-client';
+      process.env.SPOTIFY_SECRET = 'supersecret';
       const tokens = await refreshToken('valid');
       expect(tokens).toHaveProperty('access_token');
       expect(tokens).toHaveProperty('expires_in');
     });
+    it('should refresh access token from passed-in variables', async () => {
+      const tokens = await refreshToken('valid', 'valid-client', 'supersecret');
+      expect(tokens).toHaveProperty('access_token');
+      expect(tokens).toHaveProperty('expires_in');
+    });
     it('should throw on invalid refresh token', async () => {
+      process.env.REDIRECT = 'http://localhost:3000/';
+      process.env.SPOTIFY_CLIENT = 'valid-client';
+      process.env.SPOTIFY_SECRET = 'supersecret';
       await expect(() => refreshToken('invalid')).rejects.toThrow(
         'Error refreshing token'
       );
     });
   });
   describe('tokensFromCode', () => {
-    it('should return tokens when given valid code', async () => {
+    it('should return tokens when given valid code from env variable', async () => {
+      process.env.REDIRECT = 'http://localhost:3000/';
+      process.env.SPOTIFY_CLIENT = 'valid-client';
+      process.env.SPOTIFY_SECRET = 'supersecret';
       const codes = await tokensFromCode('valid');
       expect(codes).toHaveProperty('access_token');
       expect(codes).toHaveProperty('refresh_token');
     });
+    it('should return tokens when given valid code from env variable', async () => {
+      const codes = await tokensFromCode(
+        'valid',
+        'valid-client',
+        'supersecret'
+      );
+      expect(codes).toHaveProperty('access_token');
+      expect(codes).toHaveProperty('refresh_token');
+    });
     it('should throw when given invalid code', async () => {
+      process.env.REDIRECT = 'http://localhost:3000/';
+      process.env.SPOTIFY_CLIENT = 'valid-client';
+      process.env.SPOTIFY_SECRET = 'supersecret';
       await expect(() => tokensFromCode('invalid')).rejects.toThrow(
         'Error fetching token'
       );

--- a/src/auth/fetchOptions.ts
+++ b/src/auth/fetchOptions.ts
@@ -1,11 +1,13 @@
 import { toBase64 } from '../utils';
 
-export const fetchOptions = (data: Record<string, string>) => ({
+export const fetchOptions = (
+  data: Record<string, string>,
+  client: string,
+  secret: string
+) => ({
   method: 'POST',
   headers: {
-    Authorization: `Basic ${toBase64(
-      `${process.env.SPOTIFY_CLIENT}:${process.env.SPOTIFY_SECRET}`
-    )}`,
+    Authorization: `Basic ${toBase64(`${client}:${secret}`)}`,
     'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
   },
   body: new URLSearchParams(data),

--- a/src/auth/makeAuthURL.ts
+++ b/src/auth/makeAuthURL.ts
@@ -1,11 +1,15 @@
 import { toURLString } from '../utils';
 
-export const makeAuthURL = (scopes: scope[]): string =>
+export const makeAuthURL = (
+  scopes: scope[],
+  clientId?: string,
+  redirectUri?: string
+): string =>
   `https://accounts.spotify.com/authorize?${toURLString({
     response_type: 'code',
-    client_id: process.env.SPOTIFY_CLIENT,
+    client_id: clientId ?? process.env.SPOTIFY_CLIENT,
     scope: scopes.join(' '),
-    redirect_uri: process.env.REDIRECT,
+    redirect_uri: redirectUri ?? process.env.REDIRECT,
   })}`;
 
 export type scope =

--- a/src/auth/refreshToken.ts
+++ b/src/auth/refreshToken.ts
@@ -9,14 +9,20 @@ import { fetchOptions } from './fetchOptions';
  * @returns RefreshedToken
  */
 export const refreshToken = async (
-  refreshToken: string
+  refreshToken: string,
+  client: string = process.env.SPOTIFY_CLIENT,
+  secret: string = process.env.SPOTIFY_SECRET
 ): Promise<RefreshedToken> => {
   const response = await fetch(
     SPOTIFY_AUTH,
-    fetchOptions({
-      refresh_token: refreshToken,
-      grant_type: 'refresh_token',
-    })
+    fetchOptions(
+      {
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+      },
+      client,
+      secret
+    )
   );
   if (!response.ok) throw new Error('Error refreshing token');
   return (await response.json()) as RefreshedToken;

--- a/src/auth/tokensFromCode.ts
+++ b/src/auth/tokensFromCode.ts
@@ -8,14 +8,22 @@ import { fetchOptions } from './fetchOptions';
  * @param code string
  * @returns SpotifyTokens
  */
-export const tokensFromCode = async (code: string): Promise<SpotifyTokens> => {
+export const tokensFromCode = async (
+  code: string,
+  client: string = process.env.SPOTIFY_CLIENT,
+  secret: string = process.env.SPOTIFY_SECRET
+): Promise<SpotifyTokens> => {
   const response = await fetch(
     SPOTIFY_AUTH,
-    fetchOptions({
-      code,
-      redirect_uri: process.env.REDIRECT,
-      grant_type: 'authorization_code',
-    })
+    fetchOptions(
+      {
+        code,
+        redirect_uri: process.env.REDIRECT,
+        grant_type: 'authorization_code',
+      },
+      client,
+      secret
+    )
   );
   if (!response.ok) throw new Error('Error fetching token');
 


### PR DESCRIPTION
This PR:
- Adds tests to allow for both `ENV` variables, as well as passed in variables
- Adjusts all Auth Helpers to work with both