### PR TITLE
:ambulance: Fixes issue with liking/unliking tracks failing

### DIFF
--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "7.35 kB",
-    "raw": 7346
+    "pretty": "7.38 kB",
+    "raw": 7384
   },
   "gzipped": {
-    "pretty": "2.69 kB",
-    "raw": 2689
+    "pretty": "2.71 kB",
+    "raw": 2710
   }
 }

--- a/src/endpoints/tracks/removeTracks.ts
+++ b/src/endpoints/tracks/removeTracks.ts
@@ -13,11 +13,11 @@ export const removeTracks: RemoveTracks = ((
 ): QueryFunction<Promise<boolean>> | QueryFunction<Promise<boolean[]>> => {
   if (Array.isArray(ids))
     return (client) =>
-      Promise.all(ids.map((id) => cacheSavedTracks(client, id)));
-  return (client) => cacheSavedTracks(client, ids);
+      Promise.all(ids.map((id) => cacheRemovedTracks(client, id)));
+  return (client) => cacheRemovedTracks(client, ids);
 }) as RemoveTracks;
 
-const cacheSavedTracks = async (
+const cacheRemovedTracks = async (
   { token, cache }: PersistentApiProperties,
   track: string
 ): Promise<boolean> => {
@@ -29,11 +29,16 @@ const cacheSavedTracks = async (
 const batchRemoveTracks: BatchedFunction<boolean> = batchWrap(
   async (token, ids) => {
     const endpoint = `me/tracks`;
-    const data = await spotifyFetch<boolean[]>(endpoint, token, {
-      method: 'DELETE',
-      body: JSON.stringify({ ids }),
-    });
-    return data;
+    await spotifyFetch<boolean[]>(
+      endpoint,
+      token,
+      {
+        method: 'DELETE',
+        body: JSON.stringify({ ids }),
+      },
+      false
+    );
+    return ids.map(() => false);
   }
 );
 

--- a/src/endpoints/tracks/saveOrRemoveTracks.test.ts
+++ b/src/endpoints/tracks/saveOrRemoveTracks.test.ts
@@ -13,9 +13,6 @@ describe('saveTracks', () => {
         if (!req.body) return { statusCode: 403 };
         return {
           statusCode: 200,
-          data: (JSON.parse(req.body as string) as { ids: string[] }).ids.map(
-            () => true
-          ),
         };
       },
     }).persist();
@@ -54,9 +51,6 @@ describe('removeTracks', () => {
         if (!req.body) return { statusCode: 403 };
         return {
           statusCode: 200,
-          data: (JSON.parse(req.body as string) as { ids: string[] }).ids.map(
-            () => true
-          ),
         };
       },
     }).persist();
@@ -64,19 +58,19 @@ describe('removeTracks', () => {
   it('should return a function', () => {
     expect(typeof removeTracks('seoul')).toBe('function');
   });
-  it('should save tracks', async () => {
+  it('should remove tracks', async () => {
     const wasRemoved = await removeTracks('seoul')({
       token: 'token',
       cache: { saved: { tracks: {} } } as PersistentApiProperties['cache'],
     });
-    expect(wasRemoved).toEqual(true);
+    expect(wasRemoved).toEqual(false);
   });
   it('should accept an array of tracks', async () => {
     const wasRemoved = await removeTracks(['seoul', 'drip'])({
       token: 'token',
       cache: { saved: { tracks: {} } } as PersistentApiProperties['cache'],
     });
-    expect(wasRemoved).toEqual([true, true]);
+    expect(wasRemoved).toEqual([false, false]);
   });
   it('should cache result', async () => {
     const cache = {

--- a/src/endpoints/tracks/saveTracks.ts
+++ b/src/endpoints/tracks/saveTracks.ts
@@ -29,11 +29,16 @@ const cacheSavedTracks = async (
 const batchSaveTracks: BatchedFunction<boolean> = batchWrap(
   async (token, ids) => {
     const endpoint = `me/tracks`;
-    const data = await spotifyFetch<boolean[]>(endpoint, token, {
-      method: 'PUT',
-      body: JSON.stringify({ ids }),
-    });
-    return data;
+    await spotifyFetch<boolean[]>(
+      endpoint,
+      token,
+      {
+        method: 'PUT',
+        body: JSON.stringify({ ids }),
+      },
+      false
+    );
+    return ids.map(() => true);
   }
 );
 


### PR DESCRIPTION
This PR:
- Fixes issue with parsing blank JSON response from Shopify API

I'm so positive this used to work, but currently, the API returns nothing when adding or removing a track from the list, causing these endpoints to fail.

Now they return the new set state.

These are able to be further optimized to reuse code, but don't yet.